### PR TITLE
Unmount loop0 before use

### DIFF
--- a/qt-modules.txt
+++ b/qt-modules.txt
@@ -6,3 +6,4 @@ qtquickcontrols
 qtquickcontrols2
 qtserialport
 qtsvg
+qtgraphicaleffects

--- a/utils/prepare-sysroot-full.sh
+++ b/utils/prepare-sysroot-full.sh
@@ -7,6 +7,7 @@ mkdir -p raspbian ; cd raspbian
 
 # Mount and extract the raspbian sysroot
 message 'Creating sysroot'
+sudo umount /dev/loop0
 sudo losetup -P /dev/loop0 ${RASPBIAN_BASENAME}.img
 sudo mkdir /mnt/raspbian
 sudo mount /dev/loop0p2 /mnt/raspbian


### PR DESCRIPTION
/dev/loop0 can be used by other programs. Make sure it is not mounted so it can be used.